### PR TITLE
fix: 사용하지 않는 import 삭제 (React)

### DIFF
--- a/ZzicGo_fe/src/App.tsx
+++ b/ZzicGo_fe/src/App.tsx
@@ -1,5 +1,5 @@
 import "./index.css";
-import { useEffect, useState } from "react";
+// import { useEffect, useState } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 
@@ -8,7 +8,7 @@ import RootLayout from "./layouts/RootLayout";
 // 페이지 컴포넌트들 ...
 import NotFoundPage from "./pages/common/NotFoundPage";
 import SplashPage from "./pages/common/SplashPage";
-import MainPage from "./pages/MainPage";
+// import MainPage from "./pages/MainPage";
 
 // 📄 소셜 로그인 관련 컴포넌트
 import SocialLogin from "./components/auth/SocialLogin";


### PR DESCRIPTION
Close #10  #12 

## 📝 작업 내용
사용하지 않은 리액트 import 삭제
## ✅ 변경 사항
- [ ] App.tsx에서 아래의 두 코드 주석 처리
```tsx
// import { useEffect, useState } from "react";
// import MainPage from "./pages/MainPage";
```


## 📷 스크린샷 (선택)
## 💬 리뷰어에게