### PR TITLE
fix(#76): 403에러 반환으로 인해 토큰 재발급 안되는 오류 수정

### DIFF
--- a/ZzicGo_be/src/main/java/com/ZzicGo/config/jwt/JwtAuthenticationFilter.java
+++ b/ZzicGo_be/src/main/java/com/ZzicGo/config/jwt/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = authHeader.substring(7);
 
         if (!jwtProvider.validateToken(token)) {
-            filterChain.doFilter(request, response);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 


### PR DESCRIPTION
Closed : #75 

## 📝 작업 내용
fix(#75): 403에러 반환으로 인해 토큰 재발급 안되는 오류 수정

## ✅ 변경 사항
- [x]  토큰이 유효하지 않을 경우 jwtfilter에서 바로 401 반환

## 📷 스크린샷 (선택)

before:
<img width="621" height="180" alt="image" src="https://github.com/user-attachments/assets/b61b50a2-577a-4adb-ad7a-f38bbd68b0ed" />

after:
<img width="627" height="179" alt="image" src="https://github.com/user-attachments/assets/eebe001e-9052-4567-a4f7-2c4f36a6b98a" />


## 💬 리뷰어에게
