### PR TITLE
fix: 인증 기록 조회 api 응답에서 imageId 필드를 추가

### DIFF
--- a/ZzicGo_be/src/main/java/com/ZzicGo/dto/HistoryResponseDto.java
+++ b/ZzicGo_be/src/main/java/com/ZzicGo/dto/HistoryResponseDto.java
@@ -68,8 +68,16 @@ public class HistoryResponseDto {
     public static class GetHistoryResponse {
         private Long historyId;
         private String content;
-        private List<String> images; // presigned URL 목록
+        private List<HistoryImageDetail> images; // image Id
         private String visibility;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class HistoryImageDetail {
+        private Long imageId;   // image Id
+        private String imageUrl; // presigned URL 목록
     }
 
 }

--- a/ZzicGo_be/src/main/java/com/ZzicGo/dto/HistoryResponseDto.java
+++ b/ZzicGo_be/src/main/java/com/ZzicGo/dto/HistoryResponseDto.java
@@ -68,7 +68,7 @@ public class HistoryResponseDto {
     public static class GetHistoryResponse {
         private Long historyId;
         private String content;
-        private List<HistoryImageDetail> images; // image Id
+        private List<HistoryImageDetail> images;
         private String visibility;
     }
 
@@ -77,7 +77,7 @@ public class HistoryResponseDto {
     @Builder
     public static class HistoryImageDetail {
         private Long imageId;   // image Id
-        private String imageUrl; // presigned URL 목록
+        private String imageUrl; // presigned URL
     }
 
 }

--- a/ZzicGo_be/src/main/java/com/ZzicGo/service/HistoryService.java
+++ b/ZzicGo_be/src/main/java/com/ZzicGo/service/HistoryService.java
@@ -132,7 +132,7 @@ public class HistoryService {
         List<HistoryResponseDto.HistoryImageDetail> imageDetails = historyImages.stream()
                 .map(image -> HistoryResponseDto.HistoryImageDetail.builder()
                         .imageId(image.getId())
-                        .imageUrl(image.getImageUrl())
+                        .imageUrl(s3Uploader.getPresignedUrl(image.getImageUrl()))
                         .build())
                 .toList();
 

--- a/ZzicGo_be/src/main/java/com/ZzicGo/service/HistoryService.java
+++ b/ZzicGo_be/src/main/java/com/ZzicGo/service/HistoryService.java
@@ -123,10 +123,17 @@ public class HistoryService {
             throw new CustomException(HistoryException.HISTORY_FORBIDDEN);
         }
 
+        List<ImageUrl> historyImages = imageUrlRepository.findByHistoryId(history.getId());
 
-        List<String> imageUrls = imageUrlRepository.findByHistoryId(history.getId())
-                .stream()
+        List<String> imageUrls = historyImages.stream()
                 .map(ImageUrl::getImageUrl)
+                .toList();
+
+        List<HistoryResponseDto.HistoryImageDetail> imageDetails = historyImages.stream()
+                .map(image -> HistoryResponseDto.HistoryImageDetail.builder()
+                        .imageId(image.getId())
+                        .imageUrl(image.getImageUrl())
+                        .build())
                 .toList();
 
 
@@ -134,7 +141,7 @@ public class HistoryService {
         return HistoryResponseDto.GetHistoryResponse.builder()
                 .historyId(history.getId())
                 .content(history.getContent())
-                .images(imageUrls)
+                .images(imageDetails)
                 .visibility(history.getVisibility().toString())
                 .build();
     }


### PR DESCRIPTION
Closed : #63 

## 📝 작업 내용
인증 기록 조회 api 응답에서 imageId 필드를 추가

## ✅ 변경 사항
- [x]  인증 기록 조회 api 응답에서 imageId 필드를 추가

## 📷 스크린샷 (선택)
<img width="587" height="253" alt="image" src="https://github.com/user-attachments/assets/f8ed8386-8e58-4303-8cf0-e8a2bb1cf8b1" />


## 💬 리뷰어에게
