### PR TITLE
fix: 인증 기록 조회 api 응답에서 imageId 필드를 추가 수정

### DIFF
--- a/ZzicGo_be/src/main/java/com/ZzicGo/dto/HistoryResponseDto.java
+++ b/ZzicGo_be/src/main/java/com/ZzicGo/dto/HistoryResponseDto.java
@@ -68,7 +68,7 @@ public class HistoryResponseDto {
     public static class GetHistoryResponse {
         private Long historyId;
         private String content;
-        private List<HistoryImageDetail> images; // image Id
+        private List<HistoryImageDetail> images;
         private String visibility;
     }
 
@@ -77,7 +77,7 @@ public class HistoryResponseDto {
     @Builder
     public static class HistoryImageDetail {
         private Long imageId;   // image Id
-        private String imageUrl; // presigned URL 목록
+        private String imageUrl; // presigned URL
     }
 
 }

--- a/ZzicGo_be/src/main/java/com/ZzicGo/service/HistoryService.java
+++ b/ZzicGo_be/src/main/java/com/ZzicGo/service/HistoryService.java
@@ -125,14 +125,10 @@ public class HistoryService {
 
         List<ImageUrl> historyImages = imageUrlRepository.findByHistoryId(history.getId());
 
-        List<String> imageUrls = historyImages.stream()
-                .map(ImageUrl::getImageUrl)
-                .toList();
-
         List<HistoryResponseDto.HistoryImageDetail> imageDetails = historyImages.stream()
                 .map(image -> HistoryResponseDto.HistoryImageDetail.builder()
                         .imageId(image.getId())
-                        .imageUrl(image.getImageUrl())
+                        .imageUrl(s3Uploader.getPresignedUrl(image.getImageUrl()))
                         .build())
                 .toList();
 


### PR DESCRIPTION
related : #82  (내용 동일)

## 📝 작업 내용
인증 기록 조회 api 응답에서 imageId 필드를 추가

## ✅ 변경 사항
- [x]  인증 기록 조회 api 응답에서 imageId 필드를 추가

## 📷 스크린샷 (선택)
<img width="587" height="253" alt="image" src="https://github.com/user-attachments/assets/f8ed8386-8e58-4303-8cf0-e8a2bb1cf8b1" />


## 💬 리뷰어에게
